### PR TITLE
rename conflicting beans to use correct one and add component scan

### DIFF
--- a/src/main/java/gov/va/schema/emis/vdrdodadapter/v2/DoDAdapterClient.java
+++ b/src/main/java/gov/va/schema/emis/vdrdodadapter/v2/DoDAdapterClient.java
@@ -3,6 +3,7 @@ package gov.va.schema.emis.vdrdodadapter.v2;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.ws.client.core.WebServiceTemplate;
 
 import javax.xml.bind.JAXBElement;
@@ -10,6 +11,7 @@ import javax.xml.bind.JAXBElement;
 public class DoDAdapterClient {
   private static final Logger LOGGER = LoggerFactory.getLogger(DoDAdapterClient.class);
 
+  @Qualifier("dodAdapterWebServiceTemplate")
   @Autowired private WebServiceTemplate DoDAdapterWebServiceTemplate;
 
   private ObjectFactory factory = new ObjectFactory();

--- a/src/main/java/gov/va/schema/emis/vdrdodadapter/v2/DoDAdapterClientConfig.java
+++ b/src/main/java/gov/va/schema/emis/vdrdodadapter/v2/DoDAdapterClientConfig.java
@@ -13,14 +13,14 @@ import javax.xml.soap.SOAPException;
 @Configuration
 public class DoDAdapterClientConfig {
 
-  @Bean
+  @Bean(name = "dodAdapterJaxb2Marshaller")
   Jaxb2Marshaller jaxb2Marshaller() {
     Jaxb2Marshaller jaxb2Marshaller = new Jaxb2Marshaller();
     jaxb2Marshaller.setContextPath("gov.va.schema.emis.vdrdodadapter.v2");
     return jaxb2Marshaller;
   }
 
-  @Bean
+  @Bean(name = "dodAdapterWebServiceTemplate")
   public WebServiceTemplate webServiceTemplate() throws SOAPException {
     MessageFactory messageFactory = MessageFactory.newInstance(SOAPConstants.SOAP_1_2_PROTOCOL);
     SaajSoapMessageFactory saajSoapMessageFactory = new SaajSoapMessageFactory(messageFactory);

--- a/src/main/java/gov/va/viers/cdi/emis/SpringWsApplication.java
+++ b/src/main/java/gov/va/viers/cdi/emis/SpringWsApplication.java
@@ -2,8 +2,11 @@ package gov.va.viers.cdi.emis;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
+
 
 @SpringBootApplication
+@ComponentScan({"gov.va."})
 public class SpringWsApplication {
 
   public static void main(String[] args) {


### PR DESCRIPTION
Related Story: https://vasdvp.atlassian.net/browse/API-1027

Fixed bean discovery and conflict.

- found all beans with ComponentScan annotation
- renamed with Bean annotation
- used correct bean with Qualifier annotation 
