### PR TITLE
restructure, refactor, and add an annotation

### DIFF
--- a/src/main/java/gov/va/SpringWsApplication.java
+++ b/src/main/java/gov/va/SpringWsApplication.java
@@ -1,12 +1,10 @@
-package gov.va.viers.cdi.emis;
+package gov.va;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.ComponentScan;
 
 
 @SpringBootApplication
-@ComponentScan({"gov.va."})
 public class SpringWsApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/gov/va/schema/emis/vdrdodadapter/v2/DoDAdapterClient.java
+++ b/src/main/java/gov/va/schema/emis/vdrdodadapter/v2/DoDAdapterClient.java
@@ -4,10 +4,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
 import org.springframework.ws.client.core.WebServiceTemplate;
 
 import javax.xml.bind.JAXBElement;
 
+@Component
 public class DoDAdapterClient {
   private static final Logger LOGGER = LoggerFactory.getLogger(DoDAdapterClient.class);
 

--- a/src/test/java/gov/va/viers/cdi/emis/client/DoDAdapterClientTestConfig.java
+++ b/src/test/java/gov/va/viers/cdi/emis/client/DoDAdapterClientTestConfig.java
@@ -12,7 +12,7 @@ import org.springframework.context.annotation.Profile;
 public class DoDAdapterClientTestConfig {
     @Bean
     @Primary
-    public DoDAdapterClient doDAdapterClient() {
+    public DoDAdapterClient dodAdapterClient() {
         return Mockito.mock(DoDAdapterClient.class);
     }
 }


### PR DESCRIPTION
Related Story: https://vasdvp.atlassian.net/browse/API-1028

- Removed the need to component scan by restructuring.
- Added missing component annotation to DoDAdapterClient.
- Removed bean conflict by renaming.