### PR TITLE
create Retirement mapper and tests

### DIFF
--- a/src/main/java/gov/va/dod/DoDAdapterClient.java
+++ b/src/main/java/gov/va/dod/DoDAdapterClient.java
@@ -1,6 +1,7 @@
 package gov.va.dod;
 
 import gov.va.schema.emis.vdrdodadapter.v2.EMISmilitaryServiceEligibilityResponseType;
+import gov.va.schema.emis.vdrdodadapter.v2.EMISretirementResponseType;
 import gov.va.schema.emis.vdrdodadapter.v2.EMISunitInformationResponseType;
 import gov.va.schema.emis.vdrdodadapter.v2.InputEdiPi;
 import gov.va.schema.emis.vdrdodadapter.v2.ObjectFactory;
@@ -50,6 +51,22 @@ public class DoDAdapterClient {
 
     if (response.getValue() == null) {
       response.setValue(new EMISunitInformationResponseType());
+    }
+
+    return response;
+  }
+
+  public JAXBElement<EMISretirementResponseType> getRetirementResponse(String value) {
+    InputEdiPi edipi = new InputEdiPi();
+    edipi.setEdipi(value);
+    JAXBElement<InputEdiPi> request = factory.createEMISretirementRequest(edipi);
+
+    JAXBElement<EMISretirementResponseType> response =
+        (JAXBElement<EMISretirementResponseType>)
+            DoDAdapterWebServiceTemplate.marshalSendAndReceive(request);
+
+    if (response.getValue() == null) {
+      response.setValue(new EMISretirementResponseType());
     }
 
     return response;

--- a/src/main/java/gov/va/emis/endpoint/RetirementEndpoint.java
+++ b/src/main/java/gov/va/emis/endpoint/RetirementEndpoint.java
@@ -1,0 +1,61 @@
+package gov.va.emis.endpoint;
+
+import gov.va.dod.DoDAdapterClient;
+import gov.va.emis.mappers.RetirementMapper;
+import gov.va.viers.cdi.cdi.commonservice.v2.ESSErrorType;
+import gov.va.viers.cdi.emis.requestresponse.militaryinfo.v2.ObjectFactory;
+import gov.va.viers.cdi.emis.requestresponse.v2.EMISretirementResponseType;
+import gov.va.viers.cdi.emis.requestresponse.v2.InputEdiPiOrIcn;
+import javax.xml.bind.JAXBElement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.ws.server.endpoint.annotation.Endpoint;
+import org.springframework.ws.server.endpoint.annotation.PayloadRoot;
+import org.springframework.ws.server.endpoint.annotation.RequestPayload;
+import org.springframework.ws.server.endpoint.annotation.ResponsePayload;
+import org.springframework.ws.soap.server.endpoint.annotation.SoapHeader;
+
+@Endpoint
+public class RetirementEndpoint extends EmisEndpoint {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(RetirementEndpoint.class);
+
+  private ObjectFactory objectFactory = new ObjectFactory();
+
+  @Autowired private DoDAdapterClient dodClient;
+
+  @Override
+  @PayloadRoot(
+    namespace = "http://viers.va.gov/cdi/eMIS/RequestResponse/MilitaryInfo/v2",
+    localPart = "eMISretirementRequest"
+  )
+  @ResponsePayload
+  public JAXBElement processRequest(
+      @RequestPayload InputEdiPiOrIcn request,
+      @SoapHeader(value = "{http://viers.va.gov/cdi/CDI/commonService/v2}inputHeaderInfo")
+          org.springframework.ws.soap.SoapHeader headerInfo) {
+    return super.processRequest(request, headerInfo);
+  }
+
+  @Override
+  JAXBElement makeEmisError(ESSErrorType error) {
+    EMISretirementResponseType errorResponse = new EMISretirementResponseType();
+    errorResponse.setESSError(error);
+    return objectFactory.createEMISretirementResponse(errorResponse);
+  }
+
+  @Override
+  ResponseTuple sendRequest(String edipi) {
+    JAXBElement<gov.va.schema.emis.vdrdodadapter.v2.EMISretirementResponseType> vadirResponse =
+        dodClient.getRetirementResponse(edipi);
+
+    ResponseTuple tuple = new ResponseTuple();
+
+    EMISretirementResponseType mappedResponse =
+        RetirementMapper.INSTANCE.mapEMISretirementResponseType(vadirResponse.getValue());
+    tuple.setResponse(objectFactory.createEMISretirementResponse(mappedResponse));
+    tuple.setError(vadirResponse.getValue().getESSError());
+    return tuple;
+  }
+}

--- a/src/main/java/gov/va/emis/mappers/RetirementMapper.java
+++ b/src/main/java/gov/va/emis/mappers/RetirementMapper.java
@@ -1,0 +1,25 @@
+package gov.va.emis.mappers;
+
+import gov.va.viers.cdi.emis.commonservice.v2.KeyData;
+import gov.va.viers.cdi.emis.commonservice.v2.Retirement;
+import gov.va.viers.cdi.emis.commonservice.v2.RetirementData;
+import gov.va.viers.cdi.emis.requestresponse.v2.EMISretirementResponseType;
+import java.util.List;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper()
+public interface RetirementMapper {
+
+  RetirementMapper INSTANCE = Mappers.getMapper(RetirementMapper.class);
+
+  EMISretirementResponseType mapEMISretirementResponseType(
+      gov.va.schema.emis.vdrdodadapter.v2.EMISretirementResponseType emisRetirementResponseType);
+
+  List<Retirement> mapRetirementList(
+      List<gov.va.schema.emis.vdrdodadapter.v2.Retirement> retirementList);
+
+  KeyData mapKeyData(gov.va.schema.emis.vdrdodadapter.v2.KeyData keyData);
+
+  RetirementData retirementData(gov.va.schema.emis.vdrdodadapter.v2.RetirementData retirementData);
+}

--- a/src/main/java/gov/va/emis/mappers/UnitInformationMapper.java
+++ b/src/main/java/gov/va/emis/mappers/UnitInformationMapper.java
@@ -15,7 +15,7 @@ public interface UnitInformationMapper {
 
   EMISunitInformationResponseType mapEMISunitInformationResponseType(
       gov.va.schema.emis.vdrdodadapter.v2.EMISunitInformationResponseType
-          emiSunitInformationResponseTypeResponseType);
+          emiSunitInformationResponseType);
 
   List<UnitInformation> mapUnitInformationList(
       List<gov.va.schema.emis.vdrdodadapter.v2.UnitInformation> unitInformationList);

--- a/src/main/resources/samples/RetirementDodResponse.xml
+++ b/src/main/resources/samples/RetirementDodResponse.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<eMISretirementResponse xmlns="http://www.va.gov/schema/eMIS/VdrDoDAdapter/v2">
+  <retirement>
+    <edipi>1669865157</edipi>
+    <keyData>
+      <personnelOrganizationCode>22</personnelOrganizationCode>
+      <personnelCategoryTypeCode>R</personnelCategoryTypeCode>
+      <personnelSegmentIdentifier>2</personnelSegmentIdentifier>
+    </keyData>
+    <retirementData>
+      <retirementTypeCode>B</retirementTypeCode>
+      <retirementServiceCode>F</retirementServiceCode>
+      <retirementBeginDate>1997-09-01</retirementBeginDate>
+      <retirementTermDate>2017-11-21</retirementTermDate>
+      <retirementTerminationReasonCode>W</retirementTerminationReasonCode>
+    </retirementData>
+  </retirement>
+</eMISretirementResponse>

--- a/src/main/resources/samples/RetirementEmisResponse.xml
+++ b/src/main/resources/samples/RetirementEmisResponse.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<NS4:eMISretirementResponse xmlns:NS4="http://viers.va.gov/cdi/eMIS/RequestResponse/MilitaryInfo/v2">
+  <NS5:retirement xmlns:NS5="http://viers.va.gov/cdi/eMIS/RequestResponse/v2">
+    <NS6:edipi xmlns:NS6="http://viers.va.gov/cdi/eMIS/commonService/v2">1669865157</NS6:edipi>
+    <NS7:keyData xmlns:NS7="http://viers.va.gov/cdi/eMIS/commonService/v2">
+      <NS7:personnelOrganizationCode>22</NS7:personnelOrganizationCode>
+      <NS7:personnelCategoryTypeCode>R</NS7:personnelCategoryTypeCode>
+      <NS7:personnelSegmentIdentifier>2</NS7:personnelSegmentIdentifier>
+    </NS7:keyData>
+    <NS8:retirementData xmlns:NS8="http://viers.va.gov/cdi/eMIS/commonService/v2">
+      <NS8:retirementTypeCode>B</NS8:retirementTypeCode>
+      <NS8:retirementServiceCode>F</NS8:retirementServiceCode>
+      <NS8:retirementBeginDate>1997-09-01</NS8:retirementBeginDate>
+      <NS8:retirementTermDate>2017-11-21</NS8:retirementTermDate>
+      <NS8:retirementTerminationReasonCode>W</NS8:retirementTerminationReasonCode>
+    </NS8:retirementData>
+  </NS5:retirement>
+</NS4:eMISretirementResponse>

--- a/src/main/resources/vadirResponses/emptyVadirResponse_RetirementSvc.xml
+++ b/src/main/resources/vadirResponses/emptyVadirResponse_RetirementSvc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<NS1:Envelope xmlns:NS1="http://www.w3.org/2003/05/soap-envelope">
+  <NS1:Body>
+    <NS3:eMISretirementResponse xmlns:NS3="http://viers.va.gov/cdi/eMIS/RequestResponse/MilitaryInfo/v2"></NS3:eMISretirementResponse>
+  </NS1:Body>
+</NS1:Envelope>

--- a/src/main/resources/vadirResponses/exampleSuccessVadirResponse_RetirementSvc.xml
+++ b/src/main/resources/vadirResponses/exampleSuccessVadirResponse_RetirementSvc.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<eMISretirementResponse xmlns="http://www.va.gov/schema/eMIS/VdrDoDAdapter/v2">
+  <retirement>
+    <edipi>1669865157</edipi>
+    <keyData>
+      <personnelOrganizationCode>22</personnelOrganizationCode>
+      <personnelCategoryTypeCode>R</personnelCategoryTypeCode>
+      <personnelSegmentIdentifier>2</personnelSegmentIdentifier>
+    </keyData>
+    <retirementData>
+      <retirementTypeCode>B</retirementTypeCode>
+      <retirementServiceCode>F</retirementServiceCode>
+      <retirementBeginDate>1997-09-01</retirementBeginDate>
+      <retirementTermDate>2017-11-21</retirementTermDate>
+      <retirementTerminationReasonCode>W</retirementTerminationReasonCode>
+    </retirementData>
+  </retirement>
+</eMISretirementResponse>

--- a/src/test/java/gov/va/emis/client/MilitaryInfoClient.java
+++ b/src/test/java/gov/va/emis/client/MilitaryInfoClient.java
@@ -4,6 +4,7 @@ import gov.va.viers.cdi.cdi.commonservice.v2.InputHeaderInfo;
 import gov.va.viers.cdi.emis.commonservice.v2.InputEdipiIcn;
 import gov.va.viers.cdi.emis.requestresponse.militaryinfo.v2.ObjectFactory;
 import gov.va.viers.cdi.emis.requestresponse.v2.EMISmilitaryServiceEligibilityResponseType;
+import gov.va.viers.cdi.emis.requestresponse.v2.EMISretirementResponseType;
 import gov.va.viers.cdi.emis.requestresponse.v2.EMISunitInformationResponseType;
 import gov.va.viers.cdi.emis.requestresponse.v2.InputEdiPiOrIcn;
 import javax.xml.bind.JAXBContext;
@@ -90,6 +91,21 @@ public class MilitaryInfoClient {
     JAXBElement<EMISunitInformationResponseType> response =
         (JAXBElement<EMISunitInformationResponseType>)
             webServiceTemplate.marshalSendAndReceive(request);
+
+    return response;
+  }
+
+  public JAXBElement<EMISretirementResponseType> getRetirementResponse(
+      String value, String type, Boolean nullHeaders) {
+    InputEdiPiOrIcn input = new InputEdiPiOrIcn();
+    InputEdipiIcn edi = new InputEdipiIcn();
+    edi.setEdipiORicnValue(value);
+    edi.setInputType(type);
+    input.setEdipiORicn(edi);
+    JAXBElement<InputEdiPiOrIcn> request = requestFactory.createEMISretirementRequest(input);
+
+    JAXBElement<EMISretirementResponseType> response =
+        (JAXBElement<EMISretirementResponseType>) webServiceTemplate.marshalSendAndReceive(request);
 
     return response;
   }

--- a/src/test/java/gov/va/emis/transformer/RetirementTransformerTest.java
+++ b/src/test/java/gov/va/emis/transformer/RetirementTransformerTest.java
@@ -1,0 +1,47 @@
+package gov.va.emis.transformer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import gov.va.emis.mappers.RetirementMapper;
+import gov.va.viers.cdi.emis.requestresponse.v2.EMISretirementResponseType;
+import java.io.IOException;
+import java.io.InputStream;
+import javax.xml.bind.JAXB;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.ClassPathResource;
+
+public class RetirementTransformerTest {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(RetirementTransformerTest.class);
+  EMISretirementResponseType emisResponse;
+  gov.va.schema.emis.vdrdodadapter.v2.EMISretirementResponseType dodResponse;
+
+  public void initializeResponses() {
+    try {
+      ClassPathResource emisSampleResponse =
+          new ClassPathResource("/samples/RetirementEmisResponse.xml");
+      ClassPathResource dodSampleResponse =
+          new ClassPathResource("/samples/RetirementDodResponse.xml");
+      InputStream emisInputStream = emisSampleResponse.getInputStream();
+      InputStream dodInputStream = dodSampleResponse.getInputStream();
+      emisResponse = JAXB.unmarshal(emisInputStream, EMISretirementResponseType.class);
+      dodResponse =
+          JAXB.unmarshal(
+              dodInputStream, gov.va.schema.emis.vdrdodadapter.v2.EMISretirementResponseType.class);
+    } catch (IOException e) {
+      LOGGER.debug("File not found, check resources folder", e);
+      emisResponse = null;
+      dodResponse = null;
+    }
+  }
+
+  @Test
+  public void RetirementTransformersTest() {
+    initializeResponses();
+    EMISretirementResponseType transformedDodResponse =
+        RetirementMapper.INSTANCE.mapEMISretirementResponseType(dodResponse);
+    assertThat(transformedDodResponse).isEqualToComparingFieldByFieldRecursively(emisResponse);
+  }
+}

--- a/src/test/java/gov/va/viers/cdi/emis/retirement/RetirementTests.java
+++ b/src/test/java/gov/va/viers/cdi/emis/retirement/RetirementTests.java
@@ -1,0 +1,85 @@
+package gov.va.viers.cdi.emis.retirement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import gov.va.dod.DoDAdapterClient;
+import gov.va.emis.client.MilitaryInfoClient;
+import gov.va.schema.emis.vdrdodadapter.v2.EMISretirementResponseType;
+import gov.va.schema.emis.vdrdodadapter.v2.ObjectFactory;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Optional;
+import javax.xml.bind.JAXB;
+import javax.xml.bind.JAXBElement;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@ActiveProfiles("test")
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+public class RetirementTests {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(RetirementTests.class);
+
+  @Autowired private MilitaryInfoClient emisClient;
+
+  @Autowired private DoDAdapterClient dodClient;
+
+  private void initMock(String sampleResponsePath, String edipi) {
+    EMISretirementResponseType dodResponse;
+    try {
+      // Grabbing from classpath
+      ClassPathResource sampleResponse =
+          new ClassPathResource("/vadirResponses/" + sampleResponsePath);
+      InputStream inputStream = sampleResponse.getInputStream();
+      dodResponse = JAXB.unmarshal(inputStream, EMISretirementResponseType.class);
+    } catch (IOException e) {
+      LOGGER.debug("Could not find " + sampleResponsePath + ", check resources folder: " + e);
+      dodResponse = null;
+    }
+    // Have to wrap in JAXBElement to match method signature
+    ObjectFactory objectFactory = new ObjectFactory();
+    JAXBElement<EMISretirementResponseType> jaxbDodResponse =
+        objectFactory.createEMISretirementResponse(dodResponse);
+    Mockito.doReturn(jaxbDodResponse).when(dodClient).getRetirementResponse(edipi);
+  }
+
+  @Test
+  public void getRetirementEmptyResponse() {
+    initMock("emptyVadirResponse_RetirementSvc.xml", "1234567890");
+    JAXBElement<gov.va.viers.cdi.emis.requestresponse.v2.EMISretirementResponseType> response =
+        emisClient.getRetirementResponse("1234567890", "EDIPI", false);
+
+    assertThat(
+        Optional.ofNullable(response)
+            .map(r -> r.getValue())
+            .map(v -> v.getRetirement())
+            .orElse(null)
+            .isEmpty());
+  }
+
+  @Test
+  public void getRetirementSuccess() {
+    initMock("exampleSuccessVadirResponse_RetirementSvc.xml", "1669865157");
+    JAXBElement<gov.va.viers.cdi.emis.requestresponse.v2.EMISretirementResponseType> response =
+        emisClient.getRetirementResponse("1669865157", "EDIPI", false);
+
+    assertThat(
+            Optional.ofNullable(response)
+                .map(r -> r.getValue())
+                .map(v -> v.getRetirement())
+                .flatMap(m -> m.stream().findFirst())
+                .map(e -> e.getRetirementData())
+                .map(s -> s.getRetirementServiceCode())
+                .orElse(null))
+        .isEqualTo("F");
+  }
+}


### PR DESCRIPTION
Related Stories: 
https://vasdvp.atlassian.net/browse/API-986
https://vasdvp.atlassian.net/browse/API-1123
https://vasdvp.atlassian.net/browse/API-1124

- created Retirement Mapper
- created Retirement Mapper tests
- created Retirement Endpoint
- added method to clients to support Retirement
- created tests for Retirement endpoint
- fixed response type name in unit information mapper